### PR TITLE
fix: Set correct peerDependency on gatsby

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "typescript": "^3.8.3"
     },
     "peerDependencies": {
-        "gatsby": ">2.0.0-alpha"
+        "gatsby": "^3.0.0 || ^2.0.0"
     },
     "author": "Jari Zwarts <jarizw@gmail.com>",
     "license": "MIT",


### PR DESCRIPTION
Hello @jariz @JoshuaWalsh, Gatsby maintainer here 👋 

While looking at your plugin I noticed that the `peerDependency` on `gatsby` is set incorrectly. We're in the process of providing more helpful information on the `/plugins` page of our website and for that we need plugins to set their `peerDependencies` correctly/more specific.

At the moment you say that _any_ version (v3, v4, v5, v6, etc.) will work with this even when in between we'd introduce breaking changes.

Making it more explicit is the safer choice (in the future you'll be able to mark breaking changes with explicit version ranges) and will allow us to display the plugin as compatible to versions X, Y, Z.

Thanks!